### PR TITLE
bug fix in group conv and add test for group conv

### DIFF
--- a/tests/test_clifford_convolution.py
+++ b/tests/test_clifford_convolution.py
@@ -27,6 +27,18 @@ def test_complex_convolution():
     output_c = F.conv1d(input_c, w_c, b_c)
     torch.testing.assert_close(output_clifford_conv, torch.view_as_real(output_c))
 
+def test_complex_grouped_convolution():
+    """Test Clifford1d grouped convolution module against complex convolution module using g = [-1]."""
+    in_channels = 8
+    out_channels = 16
+    x = torch.randn(1, in_channels, 128, 2)
+    clifford_conv = CliffordConv1d(g=[-1], in_channels=in_channels, out_channels=out_channels, kernel_size=3, groups=4)
+    output_clifford_conv = clifford_conv(x)
+    w_c = torch.view_as_complex(torch.stack((clifford_conv.weight[0], clifford_conv.weight[1]), -1))
+    b_c = torch.view_as_complex(clifford_conv.bias.permute(1, 0).contiguous())
+    input_c = torch.view_as_complex(x)
+    output_c = F.conv1d(input_c, w_c, b_c, groups=4)
+    torch.testing.assert_close(output_clifford_conv, torch.view_as_real(output_c))
 
 def test_Clifford1d_conv_shapes():
     """Test shapes of Clifford1d convolution module."""


### PR DESCRIPTION
Convolution was previously working and tested only for `groups=1`. When using other values for `groups` this gave incorrect results, for example testing Clifford 1d group convolution with `g = [-1]` against complex group convolution gave different results.

The issue was caused by the data layout.
Let's consider a 1d convolution for simplicity. Then the weight for this convolution has shape:
                          `weight.shape =[number_of_blades, output_channels, input_channels / groups, kernel_size]`
The corresponding clifford kernel has shape:
          `kernel.shape = [number_of_blades * output_channels, number_of_blades * input_channels / groups, kernel_size]`
The shape of the output of the convolution is:
                  `output.shape = [batch_size, number_of_blades * output_channels, output_length]`
Where it is expected that `output[:output_channels]` is the first blade and `output[output_channels:2 * output_channels]` is the second blade. However this is not what is happening, since each filter has `number_of_blades * input_channels / groups` channels and:

- In the first half of the filters the first half is the scalar part of the weight, the second half is the e1 part multiplied by `g[0]` (those are the filters expected to generate the scalar part of the output)
- In the second half of the filters the first half is the e1 part of the weight, the second half is the scalar part (those are the filters expected to generate the e1 part of the output)

In grouped convolution with 2 groups, the first half of the filters is assigned to the first half of the input channels, while the second half of the filters is assigned to the second half of the input channels. Each filter always expect the first half of its input channels to be the scalar part and the second part to be the e1 part, however it happens that all of its input channels are actually either all scalar or all e1!

To make group convolution work correctly, scalar and e1 channels should be interleaved to match the kernel. This reasoning can be generalised for all the other clifford algebras, and this was implemented in the last commit. Moreover a test was added to test Clifford group convolution with `g = [-1] `against complex group convolution. This test now passes, while it was previously failing. All the other tests are still passing as before.
